### PR TITLE
Remove Sql batches

### DIFF
--- a/config.go
+++ b/config.go
@@ -82,9 +82,8 @@ func WriteConfig(rows *sql.Rows) *Converter {
 		WriteHeaders:          true,
 		Delimiter:             ',',
 		CompressionLevel:      flate.DefaultCompression,
-		GzipGoroutines:        runtime.GOMAXPROCS(0),
-		GzipBatchPerGoroutine: 1 * 1024 * 1024,
-		UploadPartSize:        5 * 1024 * 1025, // Should be greater than 1 * 1024 * 1024 for pgzip
+		GzipGoroutines:        runtime.GOMAXPROCS(0), // Should be atleast the number of cores. Not sure how it impacts cgroup limits.
+		GzipBatchPerGoroutine: 512 * 1024,            // Should be atleast 100K
 		LogLevel:              Info,
 	}
 }
@@ -96,8 +95,9 @@ func UploadConfig(rows *sql.Rows) *Converter {
 		WriteHeaders:          true,
 		Delimiter:             ',',
 		CompressionLevel:      flate.DefaultCompression,
-		GzipGoroutines:        runtime.GOMAXPROCS(0),
-		GzipBatchPerGoroutine: 1 * 1024 * 1024,
+		GzipGoroutines:        runtime.GOMAXPROCS(0), // Should be atleast the number of cores. Not sure how it impacts cgroup limits.
+		GzipBatchPerGoroutine: 512 * 1024,            // Should be atleast 100K
+		LogLevel:              Info,
 		S3Upload:              true,
 		UploadThreads:         runtime.GOMAXPROCS(0),
 		UploadPartSize:        50 * 1024 * 1025, // Should be greater than 5 * 1024 * 1024 for s3 upload
@@ -105,6 +105,5 @@ func UploadConfig(rows *sql.Rows) *Converter {
 		S3Path:                os.Getenv("S3_PATH"),
 		S3Region:              os.Getenv("S3_REGION"),
 		S3Acl:                 os.Getenv("S3_ACL"),
-		LogLevel:              Info,
 	}
 }

--- a/config.go
+++ b/config.go
@@ -37,7 +37,6 @@ type Converter struct {
 	WriteHeaders          bool     // Flag to output headers in your CSV (default is true)
 	TimeFormat            string   // Format string for any time.Time values (default is time's default)
 	Delimiter             rune     // Delimiter to use in your CSV (default is comma)
-	SqlBatchSize          int
 	CompressionLevel      int
 	GzipGoroutines        int
 	GzipBatchPerGoroutine int

--- a/config.go
+++ b/config.go
@@ -48,6 +48,7 @@ type Converter struct {
 	S3Upload              bool
 	UploadThreads         int
 	UploadPartSize        int
+	RowCount              int64
 
 	s3Svc            *s3.S3
 	s3Resp           *s3.CreateMultipartUploadOutput

--- a/config.go
+++ b/config.go
@@ -37,6 +37,7 @@ type Converter struct {
 	WriteHeaders          bool     // Flag to output headers in your CSV (default is true)
 	TimeFormat            string   // Format string for any time.Time values (default is time's default)
 	Delimiter             rune     // Delimiter to use in your CSV (default is comma)
+	CsvBufferSize         int
 	CompressionLevel      int
 	GzipGoroutines        int
 	GzipBatchPerGoroutine int
@@ -80,6 +81,7 @@ func WriteConfig(rows *sql.Rows) *Converter {
 		rows:                  rows,
 		WriteHeaders:          true,
 		Delimiter:             ',',
+		CsvBufferSize:         10 * 1024 * 1024,
 		CompressionLevel:      flate.DefaultCompression,
 		GzipGoroutines:        runtime.GOMAXPROCS(0), // Should be atleast the number of cores. Not sure how it impacts cgroup limits.
 		GzipBatchPerGoroutine: 512 * 1024,            // Should be atleast 100K
@@ -94,6 +96,7 @@ func UploadConfig(rows *sql.Rows) *Converter {
 		WriteHeaders:          true,
 		Delimiter:             ',',
 		CompressionLevel:      flate.DefaultCompression,
+		CsvBufferSize:         10 * 1024 * 1024,
 		GzipGoroutines:        runtime.GOMAXPROCS(0), // Should be atleast the number of cores. Not sure how it impacts cgroup limits.
 		GzipBatchPerGoroutine: 512 * 1024,            // Should be atleast 100K
 		LogLevel:              Info,

--- a/csv.go
+++ b/csv.go
@@ -10,17 +10,17 @@ import (
 
 func (c *Converter) getCSVWriter() (*csv.Writer, *bytes.Buffer) {
 	// Same size as sqlRowBatch
-	var csvBuffer bytes.Buffer
+	csvBuffer := bytes.NewBuffer(make([]byte, 0, c.CsvBufferSize))
 
 	// CSV writer to csvBuffer
-	csvWriter := csv.NewWriter(&csvBuffer)
+	csvWriter := csv.NewWriter(csvBuffer)
 
 	// Set delimiter
 	if c.Delimiter != '\x00' {
 		csvWriter.Comma = c.Delimiter
 	}
 
-	return csvWriter, &csvBuffer
+	return csvWriter, csvBuffer
 }
 
 func (c *Converter) setCSVHeaders(csvWriter *csv.Writer) ([]string, int, error) {

--- a/csv.go
+++ b/csv.go
@@ -23,7 +23,7 @@ func (c *Converter) getCSVWriter() (*csv.Writer, *bytes.Buffer) {
 	return csvWriter, &csvBuffer
 }
 
-func (c *Converter) setCSVHeaders() ([]string, int, error) {
+func (c *Converter) setCSVHeaders(csvWriter *csv.Writer) ([]string, int, error) {
 	var headers []string
 	columnNames, err := c.rows.Columns()
 	if err != nil {
@@ -39,6 +39,13 @@ func (c *Converter) setCSVHeaders() ([]string, int, error) {
 			headers = columnNames
 		}
 	}
+
+	// Write to CSV Buffer
+	err = csvWriter.Write(headers)
+	if err != nil {
+		return nil, 0, err
+	}
+	csvWriter.Flush()
 
 	return headers, len(headers), nil
 }

--- a/examples/README.md
+++ b/examples/README.md
@@ -17,7 +17,6 @@ S3Acl:                 os.Getenv("S3_ACL"),    # Optional
 
 ```
 cfg := sqltocsvgzip.WriteConfig() // To write a file
-cfg.SqlBatchSize = 4096
 ```
 
 3. Change the config when getting the default config to UploadToS3.

--- a/examples/mssql/writeToFileAdvanced/main.go
+++ b/examples/mssql/writeToFileAdvanced/main.go
@@ -72,7 +72,6 @@ func getDBConnection() string {
 func setConfig(rows *sql.Rows) (*sqltocsvgzip.Converter, error) {
 	// Get default configuration
 	config := sqltocsvgzip.WriteConfig(rows)
-	config.SqlBatchSize = 1000
 
 	return config, nil
 }

--- a/examples/mysql/writeToFileAdvanced/main.go
+++ b/examples/mysql/writeToFileAdvanced/main.go
@@ -71,7 +71,6 @@ func getDBConnection() string {
 func setConfig(rows *sql.Rows) (*sqltocsvgzip.Converter, error) {
 	// Get default configuration
 	config := sqltocsvgzip.WriteConfig(rows)
-	config.SqlBatchSize = 1000
 
 	return config, nil
 }

--- a/examples/postgres/writeToFileAdvanced/main.go
+++ b/examples/postgres/writeToFileAdvanced/main.go
@@ -72,7 +72,6 @@ func getDBConnection() string {
 func setConfig(rows *sql.Rows) (*sqltocsvgzip.Converter, error) {
 	// Get default configuration
 	config := sqltocsvgzip.WriteConfig(rows)
-	config.SqlBatchSize = 1000
 
 	return config, nil
 }

--- a/getter.go
+++ b/getter.go
@@ -6,18 +6,6 @@ import (
 	"github.com/klauspost/pgzip"
 )
 
-// getSqlBatchSize gets the size of rows to be retrieved.
-// This batch is worked upon entirely before flushing to disk.
-func (c *Converter) getSqlBatchSize(totalColumns int) {
-	// Use sqlBatchSize set by user
-	if c.SqlBatchSize != 0 {
-		return
-	}
-
-	// Default to 4096
-	c.SqlBatchSize = 4096
-}
-
 func (c *Converter) getGzipWriter(writer io.Writer) (*pgzip.Writer, error) {
 	// Use pgzip for multi-threaded
 	zw, err := pgzip.NewWriterLevel(writer, c.CompressionLevel)

--- a/sqltocsvgzip.go
+++ b/sqltocsvgzip.go
@@ -140,7 +140,6 @@ func (c *Converter) WriteFile(csvGzipFileName string) error {
 
 // Write writes the csv.gzip to the Writer provided
 func (c *Converter) Write(w io.Writer) error {
-	var countRows int64
 	writeRow := true
 	interrupt := make(chan os.Signal, 1)
 	signal.Notify(interrupt, os.Interrupt, syscall.SIGTERM)
@@ -192,7 +191,7 @@ func (c *Converter) Write(w io.Writer) error {
 		}
 
 		if writeRow {
-			countRows = countRows + 1
+			c.RowCount = c.RowCount + 1
 
 			// Write to CSV Buffer
 			err = csvWriter.Write(row)
@@ -278,7 +277,7 @@ func (c *Converter) Write(w io.Writer) error {
 	}
 
 	// Log the total number of rows processed.
-	c.writeLog(Info, fmt.Sprintf("Total sql rows processed: %v", countRows))
+	c.writeLog(Info, fmt.Sprintf("Total sql rows processed: %v", c.RowCount))
 	return nil
 }
 

--- a/sqltocsvgzip.go
+++ b/sqltocsvgzip.go
@@ -162,13 +162,7 @@ func (c *Converter) Write(w io.Writer) error {
 		valuePtrs[i] = &values[i]
 	}
 
-	// GZIP writer to underline file.csv.gzip
-	gzipBuffer, ok := w.(*bytes.Buffer)
-	if !ok {
-		return fmt.Errorf("Expected buffer. Got %T", w)
-	}
-
-	zw, err := c.getGzipWriter(gzipBuffer)
+	zw, err := c.getGzipWriter(w)
 	if err != nil {
 		return err
 	}
@@ -225,6 +219,12 @@ func (c *Converter) Write(w io.Writer) error {
 				// Upload partially created file to S3
 				// If size of the gzip file exceeds maxFileStorage
 				if c.S3Upload {
+					// GZIP writer to underline file.csv.gzip
+					gzipBuffer, ok := w.(*bytes.Buffer)
+					if !ok {
+						return fmt.Errorf("Expected buffer. Got %T", w)
+					}
+
 					if gzipBuffer.Len() >= c.UploadPartSize {
 						if c.partNumber == 10000 {
 							return fmt.Errorf("Number of parts cannot exceed 10000. Please increase UploadPartSize and try again.")
@@ -263,6 +263,13 @@ func (c *Converter) Write(w io.Writer) error {
 		if c.partNumber == 0 {
 			return nil
 		}
+
+		// GZIP writer to underline file.csv.gzip
+		gzipBuffer, ok := w.(*bytes.Buffer)
+		if !ok {
+			return fmt.Errorf("Expected buffer. Got %T", w)
+		}
+
 		// Add to Queue for multipart upload
 		c.AddToQueue(gzipBuffer, true)
 

--- a/sqltocsvgzip.go
+++ b/sqltocsvgzip.go
@@ -209,7 +209,7 @@ func (c *Converter) Write(w io.Writer) error {
 
 			// Convert from csv to gzip
 			// Writes from buffer to underlying file
-			if csvBuffer.Len() >= c.UploadPartSize {
+			if csvBuffer.Len() >= (c.GzipBatchPerGoroutine * c.GzipGoroutines) {
 				_, err = zw.Write(csvBuffer.Bytes())
 				if err != nil {
 					return err


### PR DESCRIPTION
- Remove sql batches to reduce memory footprint.
- Return Row Count to the client.
- UploadPartSize is only for S3 now. Use CsvBufferSize to set csv buffer size. (Note: This value sets the initial capacity of the buffer. This grows as per data in sql row.)
